### PR TITLE
Tg 83 Back end Authentication

### DIFF
--- a/app.js
+++ b/app.js
@@ -2,7 +2,10 @@ const express = require('express')
 const logger = require('morgan')
 const cookieParser = require('cookie-parser')
 const bodyParser = require('body-parser')
+const jwt = require('express-jwt')
 require('dotenv').config()
+
+const jwtSecret = require('./vars').TOKEN_SECRET
 
 const routers = require('./routes/init')
 
@@ -13,10 +16,31 @@ app.use(bodyParser.json())
 app.use(bodyParser.urlencoded({ extended: false }))
 app.use(cookieParser())
 
+// Add JSON Web Token functionality
+const jwtConfig = {
+  secret: jwtSecret
+}
+const unsecuredPaths = ['/login', '/users']
+const unlessConfig = {
+  path: unsecuredPaths
+}
+app.use('/', jwt(jwtConfig).unless(unlessConfig))
+
 app.use('/', routers.requests.router)
 app.use('/', routers.users.router)
 app.use('/', routers.games.router)
 app.use('/', routers.login.router)
+
+// Error handler for missing jwt
+app.use(function (err, req, res, next) {
+  if (err.name === 'UnauthorizedError') {
+    const response = {
+      success: false,
+      message: 'unauthorized'
+    }
+    res.status(401).json(response)
+  }
+})
 
 // catch 404 and forward to error handler
 app.use(function (req, res, next) {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "debug": "~2.6.3",
     "dotenv": "^4.0.0",
     "express": "~4.15.2",
+    "express-jwt": "^5.3.0",
     "jsonwebtoken": "^8.1.0",
     "lodash": "^4.17.4",
     "mongoose": "^4.11.12",

--- a/routes/requests.js
+++ b/routes/requests.js
@@ -64,6 +64,12 @@ router.post(path + '/', (req, res) => {
       return res.status(400).json(response)
     }
   }
+  const tokenUsername = req.user.username
+  const username = reqData.user
+  if (tokenUsername !== username) {
+    response.message = 'forbidden'
+    return res.status(403).json(response)
+  }
   createRequest(
     reqData.title,
     reqData.user,
@@ -115,6 +121,7 @@ router.get(path + '/:requestId', (req, res) => {
 })
 
 router.put(path + '/:requestID', (req, res) => {
+  // TODO Make sure logged in user is same as user on request
   res.send('requestId is set to ' + req.params.requestId)
 })
 

--- a/routes/users.js
+++ b/routes/users.js
@@ -129,6 +129,17 @@ router.get(path + '/:username', (req, res) => {
 })
 
 router.put(path + '/:username', (req, res) => {
+  // This is how to get the username of the signed in user
+  const tokenUsername = req.user.username
+  const username = req.params.username
+  const response = {
+    success: false,
+    message: ''
+  }
+  if (tokenUsername !== username) {
+    response.message = 'forbidden'
+    return res.status(403).json(response)
+  }
   res.send('username is set to ' + req.params.username)
 })
 


### PR DESCRIPTION
This will enable it so authentication will be enabled by default on every endpoint except for a few specified ones (namely /users and /login)

This means in order to call any of the endpoints you need to have a valid JWT as a Bearer token in the Authorization header on all requests to the back end